### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
 
 name: CI
 
+permissions:
+  contents: read
+
 jobs:
   jekyll-build:
     name: Build (jekyll gem)


### PR DESCRIPTION
Potential fix for [https://github.com/CornFlakesPC/ASRockWiki/security/code-scanning/5](https://github.com/CornFlakesPC/ASRockWiki/security/code-scanning/5)

Add an explicit top-level `permissions` block in `.github/workflows/ci.yml` so all jobs inherit least-privilege token access by default.

Best fix here (without changing functionality): add
```yml
permissions:
  contents: read
```
at the workflow root (for example, right after `name: CI` and before `jobs:`). This is sufficient for `actions/checkout` and typical read-only CI tasks shown. No imports, methods, or dependencies are needed since this is YAML workflow configuration only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
