### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update_jekyll-anchor-heading.yml
+++ b/.github/workflows/update_jekyll-anchor-heading.yml
@@ -4,6 +4,9 @@ on:
   #   # once per week
   #   - cron: "0 15 * * 0"
   workflow_dispatch:
+permissions:
+  contents: write
+  pull-requests: write
 jobs:
   update-deps:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/CornFlakesPC/ASRockWiki/security/code-scanning/3](https://github.com/CornFlakesPC/ASRockWiki/security/code-scanning/3)

Add an explicit `permissions` block in `.github/workflows/update_jekyll-anchor-heading.yml` at the workflow root (applies to all jobs).  
Because this workflow checks out code, downloads an updated vendor file, then creates a commit/branch and pull request, the minimal practical permissions are:

- `contents: write` (needed to commit/push branch changes)
- `pull-requests: write` (needed to create/update PR)

This keeps permissions explicit and constrained to required scopes while preserving current functionality. No imports/dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
