### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish-gem.yml
+++ b/.github/workflows/publish-gem.yml
@@ -3,6 +3,10 @@ name: Publish Ruby Gem
 on:
   workflow_dispatch
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   build:
     name: Publish


### PR DESCRIPTION
Potential fix for [https://github.com/CornFlakesPC/ASRockWiki/security/code-scanning/1](https://github.com/CornFlakesPC/ASRockWiki/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/publish-gem.yml` so the `GITHUB_TOKEN` is constrained to only what this workflow needs.

Best fix here (without changing workflow behavior) is to define permissions at the **workflow root** (applies to all jobs) right after the `on` trigger. Since this job checks out code and publishes to GitHub Packages, use:
- `contents: read` (for `actions/checkout`)
- `packages: write` (required to push gem to GitHub Packages)

This resolves the CodeQL finding and preserves existing functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
